### PR TITLE
[WIP] Make buildable again with new OS base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,30 @@
-FROM centos:latest
+FROM rockylinux:latest
 MAINTAINER Support <support@atomicorp.com>
 
 
 ADD default_agent /var/ossec/default_agent
+
 # copy base config
-ADD ossec.conf /var/ossec/etc/
+COPY --chmod=755 ossec.conf /var/ossec/etc/ossec.conf
+
 # Initialize the data volume configuration
 ADD data_dirs.env /data_dirs.env
-ADD init.sh /init.sh
+COPY --chmod=755 init.sh /init.sh
 
-
-
-#
 # Add the bootstrap script
-#
-ADD ossec-server.sh /ossec-server.sh
+COPY --chmod=755 ossec-server.sh /ossec-server.sh
 
 RUN \
 	yum -y update && \
-	yum -y install wget useradd postfix && \
+	yum -y install wget postfix && \
 	yum clean all && \
 	cd /root; NON_INT=1 wget -q -O - https://updates.atomicorp.com/installers/atomic |sh && \
 	yum -y install ossec-hids-server && \
-	chmod 755 /ossec-server.sh && \
-	chmod 755 /init.sh && \
   	sync && /init.sh &&\
   	sync && rm /init.sh
 
-#
 # Specify the data volume 
-#
 VOLUME ["/var/ossec/data"]
 
-# Expose ports for sharing
-EXPOSE 1514/udp 1515/tcp
-
-#
 # Define default command.
-#
 ENTRYPOINT ["/ossec-server.sh"]


### PR DESCRIPTION
Requires Buildkit to reduce container layers.
export DOCKER_BUILDKIT=1 # or configure in daemon.json
export COMPOSE_DOCKER_CLI_BUILD=1

```
root@ossec2:~/ossec-docker|master⚡ ⇒  docker-compose up -d
Creating ossec-docker_ossec_1 ... done
root@ossec2:~/ossec-docker|master⚡ ⇒  docker-compose logs -f
Attaching to ossec-docker_ossec_1
ossec_1  | Installing etc
ossec_1  | Installing rules
ossec_1  | Installing logs
ossec_1  | Installing stats
ossec_1  | Installing queue
ossec_1  | Starting ossec-authd...
ossec_1  | Bulk load file: /var/ossec/default_agent
ossec_1  | Opening: [/var/ossec/default_agent]
ossec_1  | Agent information:
ossec_1  |    ID:001
ossec_1  |    Name:DEFAULT_LOCAL_AGENT
ossec_1  |    IP Address:127.0.0.1
ossec_1  |
ossec_1  | Agent added with ID 001.
ossec_1  | Starting OSSEC HIDS 3.6.0...
ossec_1  | Started ossec-maild...
ossec_1  | Started ossec-execd...
ossec_1  | Started ossec-analysisd...
ossec_1  | 2022/02/28 05:31:33 ossec-logcollector(1905): INFO: No file configured to monitor.
ossec_1  | Started ossec-logcollector...
ossec_1  | Started ossec-remoted...
ossec_1  | Started ossec-syscheckd...
ossec_1  | Started ossec-monitord...
ossec_1  | Completed.
ossec_1  | 2022/02/28 05:31:34 ossec-analysisd: INFO: Ignoring file: '/var/ossec/active-response/ossec-hids-responses.log'
ossec_1  | 2022/02/28 05:31:34 ERROR: Cannot unlink file /queue/ossec/queue: No such file or directory
ossec_1  | 2022/02/28 05:31:34 ossec-analysisd: INFO: Started (pid: 63).
ossec_1  | 2022/02/28 05:31:34 ossec-analysisd: logstat: Unable to create stat queue: /stats/weekly-average
ossec_1  | 2022/02/28 05:31:34 ossec-analysisd: ERROR: Cannot unlink file /logs/archives/archives.log: No such file or directory
ossec_1  | 2022/02/28 05:31:34 ossec-analysisd: ERROR: Cannot unlink file /logs/alerts/alerts.log: No such file or directory
ossec_1  | 2022/02/28 05:31:34 ossec-analysisd: ERROR: Cannot unlink file /logs/firewall/firewall.log: No such file or directory
ossec_1  | 2022/02/28 05:31:34 ossec-remoted(4111): INFO: Maximum number of agents allowed: '16384'.
ossec_1  | 2022/02/28 05:31:34 ossec-remoted(1410): INFO: Reading authentication keys file.
ossec_1  | 2022/02/28 05:31:34 ossec-monitord: INFO: Started (pid: 82).
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Started (pid: 78).
ossec_1  | 2022/02/28 05:31:38 ossec-rootcheck: INFO: Started (pid: 78).
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Monitoring directory: '/etc', with options perm | size | owner | group | md5sum | sha1sum | realtime | report_changes.
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Monitoring directory: '/var/ossec/active-response', with options perm | size | owner | group | md5sum | sha1sum | realtime | report_changes.
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Monitoring directory: '/var/ossec/etc', with options perm | size | owner | group | md5sum | sha1sum | realtime | report_changes.
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Monitoring directory: '/var/ossec/agentless', with options perm | size | owner | group | md5sum | sha1sum | realtime | report_changes.
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Monitoring directory: '/bin', with options perm | size | owner | group | md5sum | sha1sum | realtime.
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Monitoring directory: '/lib64', with options perm | size | owner | group | md5sum | sha1sum | realtime.
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Monitoring directory: '/sbin', with options perm | size | owner | group | md5sum | sha1sum | realtime.
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Monitoring directory: '/usr/bin', with options perm | size | owner | group | md5sum | sha1sum | realtime.
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/mtab'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/var/tmp'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/var/ossec/queue'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/var/ossec/logs'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/var/ossec/stats'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/var/ossec/var'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/var/ossec/etc/rules.d'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/mnttab'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/grsec/learning.logs'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/hosts.deny'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/mail/statistics'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/random-seed'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/adjtime'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/httpd/logs'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/utmpx'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/wtmpx'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/cups/certs'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/httpd/modsecurity.d/'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/httpd/logs/'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/httpd/domlogs/'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/vfilters/'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/var/ossec/bin/.process_list'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/etc/prelink.cache'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: ignoring: '/var/ossec/active-response/ossec-hids-responses.log'
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Directory set for real time monitoring: '/etc'.
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Directory set for real time monitoring: '/var/ossec/active-response'.
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Directory set for real time monitoring: '/var/ossec/etc'.
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Directory set for real time monitoring: '/var/ossec/agentless'.
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Directory set for real time monitoring: '/bin'.
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Directory set for real time monitoring: '/lib64'.
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Directory set for real time monitoring: '/sbin'.
ossec_1  | 2022/02/28 05:31:38 ossec-syscheckd: INFO: Directory set for real time monitoring: '/usr/bin'.
ossec_1  | 2022/02/28 05:31:39 ossec-logcollector: INFO: Started (pid: 68).
ossec_1  | 2022/02/28 05:32:40 ossec-syscheckd: INFO: Starting syscheck scan (forwarding database).
ossec_1  | 2022/02/28 05:32:40 ossec-syscheckd: INFO: Starting syscheck database (pre-scan).
ossec_1  | 2022/02/28 05:32:40 ossec-syscheckd: INFO: Initializing real time file monitoring (not started).
ossec_1  | 2022/02/28 05:32:48 ossec-syscheckd(1124): ERROR: Could not rename file '/etc/alternatives/unversioned-python-man' to '/var/ossec/queue/diff/local/etc/alternatives/unversioned-python-man/last-entry' due to [(2)-(No such file or directory)].
ossec_1  | 2022/02/28 05:33:01 ossec-syscheckd(1124): ERROR: Could not rename file '/etc/systemd/system/syslog.service' to '/var/ossec/queue/diff/local/etc/systemd/system/syslog.service/last-entry' due to [(2)-(No such file or directory)].
```
This is the current state of this build.  I've never run OSSEC before I'm just looking to get a container based install without having to use a monolitic VM.